### PR TITLE
Added check to avoid debounce altogether if unnecessary

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,11 +154,19 @@ function startWatching(opts) {
 
         // XXX: commands might be still run concurrently
         if (opts.command) {
-            debouncedRun(
-                opts.command
-                    .replace(/\{path\}/ig, path)
-                    .replace(/\{event\}/ig, event)
-            );
+            if (opts.debounce > 0) {
+                debouncedRun(
+                    opts.command
+                        .replace(/\{path\}/ig, path)
+                        .replace(/\{event\}/ig, event)
+                );    
+            } else {
+                throttledRun(
+                    opts.command
+                        .replace(/\{path\}/ig, path)
+                        .replace(/\{event\}/ig, event)
+                );
+            }
         }
     });
 


### PR DESCRIPTION
Even when setting -d 0 the command execution is still debounced enough that filesystem move events do not fire commands correctly (on MacOS 10.13.3) - a move will register an unlink and an add, but only fires the command for the add:
With `-c echo {path} {event}`:
`mv test test1`
```
unlink:test
add:test1
test1 add
```
This PR fixes the problem by checking if debounce is required at all (based on a non-zero debounce time) and if not required, launches the command with only throttling. This results in what I assume is the correct behaviour:
With `-c echo {path} {event}`:
`mv test test1`
```
unlink:test
add:test1
test unlink
test1 add
```
I hope this is helpful and many thanks for this project.